### PR TITLE
haxe.Int64.is() is deprecated since Haxe 4.1.0

### DIFF
--- a/src/deepequal/DeepEqual.hx
+++ b/src/deepequal/DeepEqual.hx
@@ -9,6 +9,12 @@ import deepequal.Noise;
 import deepequal.Error;
 import deepequal.Stringifier.*;
 
+#if (haxe_ver >= 4.1)
+import haxe.Int64.isInt64;
+#else
+import haxe.Int64.is as isInt64;
+#end
+
 using Lambda;
 
 class DeepEqual {
@@ -68,10 +74,10 @@ private class Compare {
 			if(!Std.is(a, String)) return mismatch(e, a);
 			return simple(e, a);
 			
-		} else if(Int64.is(e)) {
+		} else if(isInt64(e)) {
 			
 			#if !java
-			if(!Int64.is(a)) return mismatch(e, a);
+			if(!isInt64(a)) return mismatch(e, a);
 			#end
 			return if((e:Int64) == (a:Int64)) Success(Noise) else mismatch(e, a);
 			

--- a/src/deepequal/Stringifier.hx
+++ b/src/deepequal/Stringifier.hx
@@ -1,9 +1,15 @@
 package deepequal;
 
+#if (haxe_ver >= 4.1)
+import haxe.Int64.isInt64;
+#else
+import haxe.Int64.is as isInt64;
+#end
+
 class Stringifier {
 	public static function stringify(v:Dynamic):String {
 		return
-			if(haxe.Int64.is(v)) haxe.Int64.toStr(v);
+			if(isInt64(v)) haxe.Int64.toStr(v);
 			else if(Std.is(v, String) || Std.is(v, Float) || Std.is(v, Bool)) haxe.Json.stringify(v);
 			else if(Std.is(v, Date)) DateTools.format(v, '%F %T');
 			else if(Std.is(v, haxe.io.Bytes)) 'bytes(hex):' + (v:haxe.io.Bytes).toHex();


### PR DESCRIPTION
Fixes #4.